### PR TITLE
add new languages to menu up to 14 June 2018

### DIFF
--- a/chef.html
+++ b/chef.html
@@ -26,15 +26,21 @@ default_distro = "lime";
 						<div class="col-md-6">
 					<select class="custom-select" id="lang" name="lang" onchange="translate();">
 						<option value="en">English</option>
+						<option value="ast">Asturianu (Asturian)</option>
 						<option value="ca">Català (Catalan)</option>
 						<option value="de">Deutsch (German)</option>
 						<option value="el">Ελληνικά (Greek)</option>
 						<option value="es">Español (Spanish)</option>
+						<option value="fr">Français (French)</option>
 						<option value="it">Italiano (Italian)</option>
 						<option value="ko">한국어 (Korean)</option>
-						<option value="pt">Português (Portuguese)</option>
+						<option value="lb">Lëtzebuergesch (Luxembourgish)</option>
+						<option value="mk">македонски (Macedonian)</option>
 						<option value="pt-br">Português/Brasileiro (Brasilian Portuguese)</option>
+						<option value="pt">Português (Portuguese)</option>
+						<option value="ru">русский (Russian)</option>
 						<option value="sv">Svenska (Swedish)</option>
+						<option value="tr">Türkçe (Turkish)</option>
 						<option value="zh-hans">中文（简体） (Mandarin Simplified)</option>
 						<option value="zh-hant">中文（繁體）‎ (Mandarin Traditional)</option>
 					</select>


### PR DESCRIPTION
add new languages to dropdown menu: Asturian, French, Luxembourgish, Macedonian, Russian, Turkish.
change order of Portuguese and Brasilian Portuguese.